### PR TITLE
fix / typo chwon -> chown

### DIFF
--- a/02/README.md
+++ b/02/README.md
@@ -67,7 +67,7 @@ pwd
 
 ```sh
 touch main.go
-chwon ubuntu:ubuntu main.go
+chown ubuntu:ubuntu main.go
 ```
 
 Go の `cmd.SysProcAttr` には、`clone(2)` に渡すのと同じような flags を渡すことができます。


### PR DESCRIPTION
typo の修正です。
よろしくお願いします。